### PR TITLE
Fix Missing Assets on GH-Pages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   title: "Glasswall SDK",
   tagline: "",
-  url: "https://filetrust.github.io",
+  url: "https://filetrust.github.io/glasswall-sdk-site",
   baseUrl: "/",
   favicon: "img/favicon.ico",
   organizationName: "filetrust", // Usually your GitHub org/user name.


### PR DESCRIPTION
- Server can't find assets because of an incorrect path. 