### PR TITLE
Updated Docusaurus Config to Fix Issue with GH-Pages Routing

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   title: "Glasswall SDK",
   tagline: "",
-  url: "https://filetrust.github.io/glasswall-sdk-site",
-  baseUrl: "/",
+  url: "https://filetrust.github.io",
+  baseUrl: "/glasswall-sdk-site/",
   favicon: "img/favicon.ico",
   organizationName: "filetrust", // Usually your GitHub org/user name.
   projectName: "glasswall-sdk-site", // Usually your repo name.


### PR DESCRIPTION
Changed the base url to the actual gh-pages endpoint (https://filetrust.github.io/glasswall-sdk-site/) instead of https://filetrust.github.io/