### PR TITLE
Fix for Trailing Slashes in Url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,6 +78,13 @@ module.exports = {
       trackingID: 'UA-165717322-1'
     }
   },
+  scripts: [
+    {
+      src: `/glasswall-sdk-site/js/fix-location.js`,
+      async: false,
+      defer: false
+    }
+  ],
   presets: [
     [
       "@docusaurus/preset-classic",

--- a/static/js/fix-location.js
+++ b/static/js/fix-location.js
@@ -1,0 +1,5 @@
+// https://github.com/facebook/docusaurus/issues/2394#issuecomment-630638096
+if (window && window.location && window.location.pathname.endsWith('/') && window.location.pathname !== '/') {
+    window.history.replaceState('', '', window.location.pathname.substr(0, window.location.pathname.length - 1));
+    console.log("replaced slash");
+}


### PR DESCRIPTION
GH-Pages adds a trailing slash if it can't find a html file, causing the paths to break in docusaurus.

Added a script to remove the trailing slash if it's present in the URL of the current page.